### PR TITLE
Make sure you get the wifi password

### DIFF
--- a/wifi-password.sh
+++ b/wifi-password.sh
@@ -75,7 +75,7 @@ fi
 sleep 2
 
 # source: http://blog.macromates.com/2006/keychain-access-from-shell/
-pwd="`security find-generic-password -ga \"$ssid\" 2>&1 >/dev/null`"
+pwd="`security find-generic-password -D 'AirPort network password' -ga \"$ssid\" 2>&1 >/dev/null`"
 
 if [[ $pwd =~ "could" ]]; then
   echo "ERROR: Could not find SSID \"$ssid\"" >&2


### PR DESCRIPTION
If you have an item in your keychain having the same name as the SSID it will not show you the SSID password, but the one from that item.

To enforce returning the wifi password, one must add the `-D 'AirPort network password'` to `/usr/bin/security` (ref: [http://apple.stackexchange.com/a/64678](http://apple.stackexchange.com/a/64678)).
