### PR TITLE
Add ZSH framework packaging and install instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,14 @@ With [Homebrew](https://github.com/Homebrew/homebrew):
 $ brew install wifi-password
 ```
 
+With [Antigen](https://github.com/zsh-users/antigen):
+
+Add `antigen bundle rauchg/wifi-password` to your `.zshrc` with your other antigen commands
+
+With [Zgen](https://github.com/tarjoilija/zgen)
+
+Add `zgen load rauchg/wifi-password` to your `.zshrc` to your `.zshrc`.
+
 or with `curl`:
 
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ Add `antigen bundle rauchg/wifi-password` to your `.zshrc` with your other antig
 
 With [Zgen](https://github.com/tarjoilija/zgen)
 
-Add `zgen load rauchg/wifi-password` to your `.zshrc` to your `.zshrc`.
+Add `zgen load rauchg/wifi-password` to your `.zshrc` with your other zgen commands
 
 or with `curl`:
 

--- a/wifi-password.plugin.zsh
+++ b/wifi-password.plugin.zsh
@@ -1,0 +1,6 @@
+# This plugin is MIT licensed.
+#
+# Make git-open easy to install and keep up to date if you're using a
+# ZSH framework like Zgen or Antigen
+
+  export PATH=${PATH}:$(dirname $0)

--- a/wifi-password.plugin.zsh
+++ b/wifi-password.plugin.zsh
@@ -3,4 +3,4 @@
 # Make git-open easy to install and keep up to date if you're using a
 # ZSH framework like Zgen or Antigen
 
-  export PATH=${PATH}:$(dirname $0)
+export PATH=$(dirname $0):${PATH}


### PR DESCRIPTION
Add zsh plugin file so that git-aware ZSH frameworks like [Zgen](https://github.com/tarjoilija/zgen) and [Antigen](https://github.com/zsh-users/antigen) can install the package and automatically periodically check for updates.
