### PR TITLE
Allow Antigen/Zgen users to use `wifi-password` as the command

### DIFF
--- a/wifi-password
+++ b/wifi-password
@@ -1,0 +1,1 @@
+wifi-password.sh


### PR DESCRIPTION
Adds a file `wifi-password` which is a symlink to `wifi-password.sh`.
